### PR TITLE
Reload current tab as well (for extensions with content scripts)

### DIFF
--- a/background.js
+++ b/background.js
@@ -55,4 +55,5 @@ chrome.webRequest.onBeforeRequest.addListener(
 
 chrome.browserAction.onClicked.addListener(function(tab) {
 	reloadExtensions();
+	chrome.tabs.reload(tab.id);
 });


### PR DESCRIPTION
Extensions with content scripts need to reload the tab as well as the extension in order to be ready for testing. Unfortunately chrome.management API can't check if the extension has a content script, so I made it always refresh the current tab after reloading extensions.
