### PR TITLE
[Bugfix] Prevent reload loop

### DIFF
--- a/background.js
+++ b/background.js
@@ -55,17 +55,17 @@ chrome.webRequest.onBeforeRequest.addListener(
     if (details.url.indexOf("http://reload.extensions") >= 0) {
 		reloadExtensions();
 		chrome.tabs.get(details.tabId, function(tab) {
-			if (tab.selected === false) {
+			const pendingURL = new URL(tab.pendingUrl);
+			const isSafeToCloseTab =
+				pendingURL.hostname === 'reload.extensions' &&
+				!tab.url; // tab has not yet committed => a newly created tab
+			if (isSafeToCloseTab) {
 				chrome.tabs.remove(details.tabId);
 			}
 		});
-		return {
-			// close the newly opened window
-			redirectUrl: chrome.extension.getURL("close.html")
-		};
     }
 
-	return {cancel: false};
+	return { cancel: true };
   },
   {
     urls: ["http://reload.extensions/"],

--- a/close.html
+++ b/close.html
@@ -1,7 +1,0 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html>
-	<head></head>
-	<body>
-		<script type="text/javascript" src="close.js"></script>
-	</body>
-</html>

--- a/close.js
+++ b/close.js
@@ -1,5 +1,0 @@
-if(window.history.length <= 1){
-	window.close();
-} else {
-	history.back();
-}


### PR DESCRIPTION
Prevent reload loop by closing the current tab if it was created for browsing "http://reload.extensions" and the "reload current tab" is enabled

Fixes #16 