### PR TITLE
update the extension to support manifest version 3

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,14 +1,14 @@
 {
 	"name": "Extensions Reloader",
-	"manifest_version": 2,
-	"version": "1.15",
+	"manifest_version": 3,
+	"version": "2.0",
 	"icons": {
 		"16": "icon16.png",
 		"48": "icon48.png",
 		"128": "icon128.png"
 	},
 	"background": {
-		"page": "background.html"
+		"service_worker": "background.js"
 	},
 	"commands": {
       "reload": {
@@ -20,17 +20,18 @@
    },
    "options_ui": {
     "page": "options.html",
-    "chrome_style": true
+    "open_in_tab": true
   },
 	"permissions": [
 		"tabs",
 		"management",
 		"storage",
-		"webRequest",
-		"webRequestBlocking",
+		"webRequest"
+	],
+	"host_permissions": [
 		"http://reload.extensions/"
 	],
-	"browser_action": {
+	"action": {
 		"default_icon": "icon19.png",
 		"default_title": "Reload Extensions"
 	},

--- a/options.js
+++ b/options.js
@@ -1,6 +1,6 @@
 // Saves options to chrome.storage.sync.
 function saveOptions() {
-  chrome.extension.getBackgroundPage().console.log('in save options...');
+	console.log('in save options');
 
   const reloadPageVal = document.getElementById('reload_page_after_extension_reload').checked;
   chrome.storage.sync.set({


### PR DESCRIPTION
Fixes issue #28 

I've done an update to mv3. It mostly consists of saving the 'state' variable in the extension's storage now. That's because service workers get shut down and their variables are reset. I have also removed 'webRequestBlocking' permission and its "blocking" related functionality in the webRequest in the background, because this is no longer avaialble in mv3. I don't know what the consequences will be for removing the "blocking" bit from the background. So far it seems to work fine.