### PR TITLE
Add option to reload specific extension instead of all unpacked extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,20 @@
 # Extensions Reloader for Chrome™
 
-Reloads all unpacked extensions with a single click.
+Reloads unpacked extensions with a single click. Choose to reload all extensions or select a specific extension in options.
 
 The extension is available for download [here](https://chrome.google.com/webstore/detail/fimgfedafeadlieiabdeeaodndnlbhid).
 
 If you've ever developed a Google Chrome™ extension, you might have wanted to automate the process of reloading your unpacked extension without the need of going through the extensions page.
 
-"Extensions Reloader" allows you to reload all unpacked extensions using three ways:
+"Extensions Reloader" allows you to reload unpacked extensions using three ways:
 
 1. The extension's toolbar button
 
 2. Browsing to "http://reload.extensions". This is intended for automating the reload process using "post build" scripts - just browse to "http://reload.extensions", and chrome will open with freshly reloaded extensions
 
 3. Using the keyboard shortcut. The default is Alt-Shift-r or Opt-Shift-r on Mac. Open `chrome://extensions/shortcuts` to customize
+
+Configure options to reload a specific extension instead of all unpacked extensions.
 
 Whenever a refresh is executed, a green "OK" badge will appear on Extensions Reloader's toolbar icon.
 

--- a/manifest.json
+++ b/manifest.json
@@ -35,5 +35,5 @@
 		"default_icon": "icon19.png",
 		"default_title": "Reload Extensions"
 	},
-	"description": "Reload all unpacked extensions using the extension's toolbar button or by browsing to \"http://reload.extensions\""
+	"description": "Reload unpacked extensions (specific extension or all) using the extension's toolbar button or by browsing to \"http://reload.extensions\""
 }

--- a/options.html
+++ b/options.html
@@ -16,6 +16,13 @@
     Reload current tab after extensions have been reloaded.
   </label>
 
+  <div style="margin-top: 15px;">
+    <label for="extension_select">Extension to reload:</label><br>
+    <select id="extension_select" style="margin-top: 5px; min-width: 300px;">
+      <option value="">All unpacked extensions</option>
+    </select>
+  </div>
+
   <button id="save">Save</button>
   <div id="status"></div>
 

--- a/options.js
+++ b/options.js
@@ -3,8 +3,10 @@ function saveOptions() {
 	console.log('in save options');
 
   const reloadPageVal = document.getElementById('reload_page_after_extension_reload').checked;
+  const selectedExtensionVal = document.getElementById('extension_select').value;
   chrome.storage.sync.set({
-    'reloadPage': reloadPageVal
+    'reloadPage': reloadPageVal,
+    'selectedExtension': selectedExtensionVal
   }, function () {
     // Update status to let user know options were saved.
     const statusEl = document.getElementById('status');
@@ -19,11 +21,38 @@ function saveOptions() {
 // Restores select box and checkbox state using the preferences stored in chrome.storage.
 function restoreOptions() {
   chrome.storage.sync.get({
-    'reloadPage': false
+    'reloadPage': false,
+    'selectedExtension': ''
   }, function (items) {
     document.getElementById('reload_page_after_extension_reload').checked = items.reloadPage;
+    document.getElementById('extension_select').value = items.selectedExtension;
   });
 }
 
-document.addEventListener('DOMContentLoaded', restoreOptions);
+// Loads available unpacked extensions into the dropdown
+function loadExtensions() {
+  const selectEl = document.getElementById('extension_select');
+
+  chrome.management.getAll(function (extensions) {
+    // Clear existing options except the "All extensions" option
+    selectEl.innerHTML = '<option value="">All unpacked extensions</option>';
+
+    for (const ext of extensions) {
+      if ((ext.installType === 'development') &&
+          (ext.enabled === true) &&
+          (ext.name !== 'Extensions Reloader')) {
+
+        const option = document.createElement('option');
+        option.value = ext.id;
+        option.textContent = ext.name;
+        selectEl.appendChild(option);
+      }
+    }
+  });
+}
+
+document.addEventListener('DOMContentLoaded', function() {
+  loadExtensions();
+  restoreOptions();
+});
 document.getElementById('save').addEventListener('click', saveOptions);


### PR DESCRIPTION
Add option to reload specific extension instead of all unpacked extensions.

## Problem
When developing with multiple unpacked extensions (e.g., using agentic feedback loops in Cursor with tools like the Playwright MCP from Microsoft), reloading ALL unpacked extensions breaks the testing cycle since other extensions may be disrupted during development.

## Solution
Added a dropdown selector in the extension options to choose either:
- "All unpacked extensions" (default behavior, backward compatible)
- A specific extension to reload

## Changes
- Added extension selector dropdown to options.html
- Updated options.js to load available extensions and save selection
- Modified background.js to check for selected extension before reloading
- Updated manifest.json and README.md to reflect new functionality

## Use Case
This enables seamless development workflows where you can reload only the extension you're actively working on, without disrupting other development tools running as unpacked extensions.